### PR TITLE
Implement quit to match vim

### DIFF
--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -305,7 +305,11 @@ def quit_all(editor, force=False):
     """
     Quit all.
     """
-    quit(editor, all_=True, force=force)
+    ebs = editor.window_arrangement.editor_buffers
+    if not force and any(eb.has_unsaved_changes for eb in ebs):
+        editor.show_message(_NO_WRITE_SINCE_LAST_CHANGE_TEXT)
+    else:
+        editor.application.exit()
 
 
 @location_cmd('w', accepts_force=True)

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -289,12 +289,10 @@ def quit(editor, force=False):
     eb_is_open_in_another_window = len(list(editor.window_arrangement.get_windows_for_buffer(eb))) > 1
     if not force and eb.has_unsaved_changes and not eb_is_open_in_another_window:
         editor.show_message(_NO_WRITE_SINCE_LAST_CHANGE_TEXT)
-    elif editor.window_arrangement.active_tab.window_count() > 1:
-        editor.window_arrangement.close_window()
-    elif len(editor.window_arrangement.tab_pages) > 1:
-        editor.window_arrangement.close_tab()
-    else:
+    elif editor.window_arrangement.active_tab.window_count() == 1 and len(editor.window_arrangement.tab_pages) == 1:
         editor.application.exit()
+    else:
+        editor.window_arrangement.close_window()
 
 
 @cmd('qa', accepts_force=True)

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -330,7 +330,7 @@ def write_and_quit(editor, location, force=False):
     Write file and quit.
     """
     write(editor, location, force=force)
-    editor.application.exit()
+    quit(editor)
 
 
 @cmd('cq')

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -358,7 +358,7 @@ def write_and_quit_all(editor):
         editor.show_message(_NO_FILE_NAME)
     else:
         eb.write()
-        quit(editor, all_=True, force=False)
+        quit_all(editor, force=False)
 
 
 @cmd('h')

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -414,7 +414,7 @@ def pwd(editor):
 def cd(editor, location):
     " Change working directory. "
     try:
-        os.chdir(location)
+        os.chdir(os.path.expanduser(location))
     except OSError as e:
         editor.show_message('{}'.format(e))
 

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -411,7 +411,7 @@ def pwd(editor):
 
 
 @location_cmd('cd', accepts_force=False)
-def pwd(editor, location):
+def cd(editor, location):
     " Change working directory. "
     try:
         os.chdir(location)

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -281,20 +281,18 @@ def buffer_edit(editor, location, force=False):
 
 @cmd('q', accepts_force=True)
 @cmd('quit', accepts_force=True)
-def quit(editor, all_=False, force=False):
+def quit(editor, force=False):
     """
     Quit.
     """
-    ebs = editor.window_arrangement.editor_buffers
-
-    # When there are buffers that have unsaved changes, show balloon.
-    if not force and any(eb.has_unsaved_changes for eb in ebs):
+    eb = editor.window_arrangement.active_editor_buffer
+    eb_is_open_in_another_window = len(list(editor.window_arrangement.get_windows_for_buffer(eb))) > 1
+    if not force and eb.has_unsaved_changes and not eb_is_open_in_another_window:
         editor.show_message(_NO_WRITE_SINCE_LAST_CHANGE_TEXT)
-
-    # When there is more than one buffer open.
-    elif not all_ and len(ebs) > 1:
-        editor.show_message('%i more files to edit' % (len(ebs) - 1))
-
+    elif editor.window_arrangement.active_tab.window_count() > 1:
+        editor.window_arrangement.close_window()
+    elif len(editor.window_arrangement.tab_pages) > 1:
+        editor.window_arrangement.close_tab()
     else:
         editor.application.exit()
 

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -208,6 +208,8 @@ def buffer_add(editor, location):
     editor.window_arrangement.open_buffer(location)
 
 
+@cmd('files')
+@cmd('ls')
 @cmd('buffers')
 def buffer_list(editor):
     """

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -344,17 +344,26 @@ def quit_nonzero(editor):
     editor.application.exit()
 
 
+@cmd('wa')
+def write_all(editor):
+    """
+    Write all changed buffers
+    """
+    for eb in editor.window_arrangement.editor_buffers:
+        if eb.location is None:
+            editor.show_message(_NO_FILE_NAME)
+            break
+        else:
+            eb.write()
+
+
 @cmd('wqa')
 def write_and_quit_all(editor):
     """
-    Write current buffer and quit all.
+    Write all changed buffers and quit all.
     """
-    eb = editor.window_arrangement.active_editor_buffer
-    if eb.location is None:
-        editor.show_message(_NO_FILE_NAME)
-    else:
-        eb.write()
-        quit_all(editor, force=False)
+    write_all(editor)
+    quit_all(editor)
 
 
 @cmd('h')

--- a/pyvim/key_bindings.py
+++ b/pyvim/key_bindings.py
@@ -52,7 +52,7 @@ def create_key_bindings(editor):
         """
         Indent current line.
         """
-        b = event.application.current_buffer
+        b = event.app.current_buffer
 
         # Move to start of line.
         pos = b.document.get_start_of_line_position(after_whitespace=True)

--- a/pyvim/key_bindings.py
+++ b/pyvim/key_bindings.py
@@ -48,6 +48,13 @@ def create_key_bindings(editor):
         write_and_quit(editor, None)
         editor.sync_with_prompt_toolkit()
 
+    @kb.add('c-z', filter=in_navigation_mode)
+    def _(event):
+        """
+        Suspend process to background.
+        """
+        event.app.suspend_to_background()
+
     @kb.add('c-t')
     def _(event):
         """

--- a/pyvim/key_bindings.py
+++ b/pyvim/key_bindings.py
@@ -4,6 +4,8 @@ from prompt_toolkit.application import get_app
 from prompt_toolkit.filters import Condition, has_focus, vi_insert_mode, vi_navigation_mode
 from prompt_toolkit.key_binding import KeyBindings
 
+from .commands.commands import write_and_quit
+
 import os
 
 __all__ = (
@@ -37,6 +39,14 @@ def create_key_bindings(editor):
 
     in_insert_mode = vi_insert_mode & vi_buffer_focussed
     in_navigation_mode = vi_navigation_mode & vi_buffer_focussed
+
+    @kb.add('Z', 'Z', filter=in_navigation_mode)
+    def _(event):
+        """
+        Write and quit.
+        """
+        write_and_quit(editor, None)
+        editor.sync_with_prompt_toolkit()
 
     @kb.add('c-t')
     def _(event):

--- a/pyvim/window_arrangement.py
+++ b/pyvim/window_arrangement.py
@@ -22,7 +22,7 @@ class HSplit(list):
 
 
 class VSplit(list):
-    """ Horizontal split. """
+    """ Vertical split. """
 
 
 class Window(object):

--- a/pyvim/window_arrangement.py
+++ b/pyvim/window_arrangement.py
@@ -103,6 +103,10 @@ class TabPage(object):
             if child == split:
                 return parent
 
+    def get_windows_for_buffer(self, editor_buffer):
+        """ Return a list of all windows in this tab page. """
+        return (window for _, window in self._walk_through_windows() if window.editor_buffer == editor_buffer)
+
     def _split(self, split_cls, editor_buffer=None):
         """
         Split horizontal or vertical.
@@ -259,6 +263,10 @@ class WindowArrangement(object):
         for eb in self.editor_buffers:
             if eb.buffer_name == buffer_name:
                 return eb
+
+    def get_windows_for_buffer(self, editor_buffer):
+        """ Return a list of all windows in this tab page. """
+        return (b for t in self.tab_pages for b in t.get_windows_for_buffer(editor_buffer))
 
     def close_window(self):
         """

--- a/pyvim/window_arrangement.py
+++ b/pyvim/window_arrangement.py
@@ -272,7 +272,10 @@ class WindowArrangement(object):
         """
         Close active window of active tab.
         """
-        self.active_tab.close_active_window()
+        if self.active_tab.window_count() > 1:
+            self.active_tab.close_active_window()
+        else:
+            self.close_tab()
 
         # Clean up buffers.
         self._auto_close_new_empty_buffers()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,5 +29,16 @@ def tab_page(window):
 
 
 @pytest.fixture
+def tab_page_with_splits(editor_buffer, window):
+    editor_buffer2 = EditorBuffer(editor)
+
+    tab_page = TabPage(Window(editor_buffer))
+    tab_page.vsplit(editor_buffer)
+    tab_page.vsplit(editor_buffer2)
+    tab_page.hsplit(editor_buffer)
+    return tab_page
+
+
+@pytest.fixture
 def window_arrangement(editor):
     return WindowArrangement(editor)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,11 +2,10 @@ from __future__ import unicode_literals
 
 import pytest
 
-from prompt_toolkit.buffer import Buffer
 from prompt_toolkit.output import DummyOutput
 from prompt_toolkit.input import DummyInput
 from pyvim.editor import Editor
-from pyvim.window_arrangement import TabPage, EditorBuffer, Window
+from pyvim.window_arrangement import TabPage, EditorBuffer, Window, WindowArrangement
 
 
 @pytest.fixture
@@ -27,3 +26,8 @@ def window(editor_buffer):
 @pytest.fixture
 def tab_page(window):
     return TabPage(window)
+
+
+@pytest.fixture
+def window_arrangement(editor):
+    return WindowArrangement(editor)

--- a/tests/test_window_arrangements.py
+++ b/tests/test_window_arrangements.py
@@ -19,34 +19,18 @@ def test_vsplit(editor, tab_page):
     assert len(tab_page.root) == 2
 
 
-def test_tab_page_get_windows_for_buffer(editor):
-    # Create new buffer.
-    eb1 = EditorBuffer(editor)
-    eb2 = EditorBuffer(editor)
+def test_tab_page_get_windows_for_buffer(editor, editor_buffer, tab_page_with_splits):
+    tab_page1 = tab_page_with_splits
 
-    # Insert in tab, by splitting.
-    tab_page1 = TabPage(Window(eb1))
-    tab_page1.vsplit(eb1)
-    tab_page1.vsplit(eb2)
-    tab_page1.hsplit(eb1)
-
-    windows = list(tab_page1.get_windows_for_buffer(eb1))
-    assert all(w.editor_buffer == eb1 for w in windows)
+    windows = list(tab_page1.get_windows_for_buffer(editor_buffer))
+    assert all(w.editor_buffer == editor_buffer for w in windows)
     assert len(windows) == 3
 
-def test_window_arrangement_get_windows_for_buffer(editor, window_arrangement):
-    # Create new buffer.
-    eb1 = EditorBuffer(editor)
-    eb2 = EditorBuffer(editor)
-
-    # Insert in tab, by splitting.
-    tab_page1 = TabPage(Window(eb1))
-    tab_page1.vsplit(eb1)
-    tab_page1.vsplit(eb2)
-    tab_page1.hsplit(eb1)
-    tab_page2 = TabPage(Window(eb1))
+def test_window_arrangement_get_windows_for_buffer(editor, editor_buffer, tab_page_with_splits, window_arrangement):
+    tab_page1 = tab_page_with_splits
+    tab_page2 = TabPage(Window(editor_buffer))
 
     window_arrangement.tab_pages[:] = [tab_page1, tab_page2]
-    windows = list(window_arrangement.get_windows_for_buffer(eb1))
-    assert all(w.editor_buffer == eb1 for w in windows)
+    windows = list(window_arrangement.get_windows_for_buffer(editor_buffer))
+    assert all(w.editor_buffer == editor_buffer for w in windows)
     assert len(windows) == 4

--- a/tests/test_window_arrangements.py
+++ b/tests/test_window_arrangements.py
@@ -26,6 +26,7 @@ def test_tab_page_get_windows_for_buffer(editor, editor_buffer, tab_page_with_sp
     assert all(w.editor_buffer == editor_buffer for w in windows)
     assert len(windows) == 3
 
+
 def test_window_arrangement_get_windows_for_buffer(editor, editor_buffer, tab_page_with_splits, window_arrangement):
     tab_page1 = tab_page_with_splits
     tab_page2 = TabPage(Window(editor_buffer))
@@ -34,3 +35,21 @@ def test_window_arrangement_get_windows_for_buffer(editor, editor_buffer, tab_pa
     windows = list(window_arrangement.get_windows_for_buffer(editor_buffer))
     assert all(w.editor_buffer == editor_buffer for w in windows)
     assert len(windows) == 4
+
+
+def test_close_window_closes_split(editor):
+    editor.window_arrangement.create_tab()
+    editor.window_arrangement.hsplit()
+    assert len(editor.window_arrangement.tab_pages) == 2
+
+    assert editor.window_arrangement.active_tab.window_count() == 2
+    editor.window_arrangement.close_window()
+    assert editor.window_arrangement.active_tab.window_count() == 1
+
+
+def test_close_window_also_closes_empty_tab(editor):
+    editor.window_arrangement.create_tab()
+
+    assert len(editor.window_arrangement.tab_pages) == 2
+    editor.window_arrangement.close_window()
+    assert len(editor.window_arrangement.tab_pages) == 1

--- a/tests/test_window_arrangements.py
+++ b/tests/test_window_arrangements.py
@@ -1,7 +1,6 @@
 from __future__ import unicode_literals
 
-from prompt_toolkit.buffer import Buffer
-from pyvim.window_arrangement import EditorBuffer, VSplit
+from pyvim.window_arrangement import EditorBuffer, VSplit, TabPage, Window
 
 
 def test_initial(window, tab_page):
@@ -18,3 +17,36 @@ def test_vsplit(editor, tab_page):
 
     assert isinstance(tab_page.root, VSplit)
     assert len(tab_page.root) == 2
+
+
+def test_tab_page_get_windows_for_buffer(editor):
+    # Create new buffer.
+    eb1 = EditorBuffer(editor)
+    eb2 = EditorBuffer(editor)
+
+    # Insert in tab, by splitting.
+    tab_page1 = TabPage(Window(eb1))
+    tab_page1.vsplit(eb1)
+    tab_page1.vsplit(eb2)
+    tab_page1.hsplit(eb1)
+
+    windows = list(tab_page1.get_windows_for_buffer(eb1))
+    assert all(w.editor_buffer == eb1 for w in windows)
+    assert len(windows) == 3
+
+def test_window_arrangement_get_windows_for_buffer(editor, window_arrangement):
+    # Create new buffer.
+    eb1 = EditorBuffer(editor)
+    eb2 = EditorBuffer(editor)
+
+    # Insert in tab, by splitting.
+    tab_page1 = TabPage(Window(eb1))
+    tab_page1.vsplit(eb1)
+    tab_page1.vsplit(eb2)
+    tab_page1.hsplit(eb1)
+    tab_page2 = TabPage(Window(eb1))
+
+    window_arrangement.tab_pages[:] = [tab_page1, tab_page2]
+    windows = list(window_arrangement.get_windows_for_buffer(eb1))
+    assert all(w.editor_buffer == eb1 for w in windows)
+    assert len(windows) == 4


### PR DESCRIPTION
This pull request implements the various ways to quit vim and/or close tabs/windows: `:q`, `:wq`, `:qa`, `:wqa`, `:wa`, and `ZZ` now behave as they would in vim. Also implements `<C-z>` (suspend_to_background).

There are also various assorted bugfixes, typofix, and adding vim aliases for existing commands. Let me know if you'd rather that these unrelated fixes be separated into their own pull requests.

This PR should fix all these tickets:

- https://github.com/prompt-toolkit/pyvim/issues/122
- https://github.com/prompt-toolkit/pyvim/issues/112
- https://github.com/prompt-toolkit/pyvim/issues/19
- https://github.com/prompt-toolkit/pyvim/issues/3
- https://github.com/prompt-toolkit/pyvim/issues/2