### PR TITLE
Implement :substitute command

### DIFF
--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -710,6 +710,8 @@ def set_scroll_offset(editor, value):
 
 
 def substitute(editor, range_start, range_end, search, replace, flags):
+    if not search:
+        search = editor.application.current_search_state.text
     if flags == 'g':
         transform_callback = lambda s: re.sub(search, replace, s)
     else:

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -734,7 +734,7 @@ def substitute(editor, range_start, range_end, search, replace, flags):
     if not search:
         search = search_state.text
 
-    if editor.last_substitute_text and replace is None:
+    if replace is None:
         replace = editor.last_substitute_text
 
     line_index_iterator = get_line_index_iterator(cursor_position_row, range_start, range_end)

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -716,9 +716,7 @@ def substitute(editor, range_start, range_end, search, replace, flags):
             range_start = range_end = cursor_position_row
         else:
             range_start = int(range_start) - 1
-            if not range_end:
-                range_end = range_start
-            range_end = int(range_end)
+            range_end = int(range_end) - 1 if range_end else range_start
         return range(range_start, range_end + 1)
 
     def get_transform_callback(search, replace, flags):

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -710,8 +710,16 @@ def set_scroll_offset(editor, value):
 
 
 def substitute(editor, range_start, range_end, search, replace, flags):
+    if editor.last_substitute_text and replace is None:
+        replace = editor.last_substitute_text
+    else:
+        editor.last_substitute_text = replace
+
     if not search:
         search = editor.application.current_search_state.text
+    else:
+        editor.application.current_search_state.text = search
+
     if flags == 'g':
         transform_callback = lambda s: re.sub(search, replace, s)
     else:

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -710,6 +710,7 @@ def set_scroll_offset(editor, value):
 
 
 def substitute(editor, range_start, range_end, search, replace, flags):
+    """ Substitute /search/ with /replace/ over a range of text """
     def get_line_index_iterator(cursor_position_row, range_start, range_end):
         if not range_start:
             range_start = range_end = cursor_position_row

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -713,6 +713,7 @@ def substitute(editor, range_start, range_end, search, replace, flags):
     """ Substitute /search/ with /replace/ over a range of text """
     def get_line_index_iterator(cursor_position_row, range_start, range_end):
         if not range_start:
+            assert not range_end
             range_start = range_end = cursor_position_row
         else:
             range_start = int(range_start) - 1
@@ -739,7 +740,8 @@ def substitute(editor, range_start, range_end, search, replace, flags):
     transform_callback = get_transform_callback(search, replace, flags)
     new_text = buffer.transform_lines(line_index_iterator, transform_callback)
 
-    new_cursor_position_row = int(range_start) - 1 if range_start and not range_end else cursor_position_row
+    assert len(line_index_iterator) >= 1
+    new_cursor_position_row = line_index_iterator[-1]
 
     # update text buffer
     buffer.document = Document(

--- a/pyvim/commands/commands.py
+++ b/pyvim/commands/commands.py
@@ -719,6 +719,7 @@ def substitute(editor, range_start, range_end, search, replace, flags):
     current_row = buffer.document.cursor_position_row
 
     if not range_end:
+        current_row = (int(range_start) - 1) if range_start else current_row
         range_end = range_start
     if range_start and range_end:
         line_index_iterator = range(int(range_start) - 1, int(range_end))

--- a/pyvim/commands/grammar.py
+++ b/pyvim/commands/grammar.py
@@ -12,7 +12,7 @@ COMMAND_GRAMMAR = compile(r"""
     \s*
     (
         # Substitute command
-        ((?P<range_start>\d+)(,(?P<range_end>\d+))?)?  (?P<command>s|substitute) \s* / (?P<search>[^/]*) / (?P<replace>[^/]*) (?P<flags> /g )?    |
+        ((?P<range_start>\d+)(,(?P<range_end>\d+))?)?  (?P<command>s|substitute) \s* / (?P<search>[^/]*) / (?P<replace>[^/]*) (?P<flags> /(g)? )?    |
 
         # Commands accepting a location.
         (?P<command>%(commands_taking_locations)s)(?P<force>!?)  \s+   (?P<location>[^\s]+)   |

--- a/pyvim/commands/grammar.py
+++ b/pyvim/commands/grammar.py
@@ -12,7 +12,7 @@ COMMAND_GRAMMAR = compile(r"""
     \s*
     (
         # Substitute command
-        ((?P<range_start>\d+)(,(?P<range_end>\d+))?)?  (?P<command>s|substitute) \s* / (?P<search>[^/]*) / (?P<replace>[^/]*) (?P<flags> /(g)? )?    |
+        ((?P<range_start>\d+)(,(?P<range_end>\d+))?)?  (?P<command>s|substitute) \s* / (?P<search>[^/]*) ( / (?P<replace>[^/]*) (?P<flags> /(g)? )? )?   |
 
         # Commands accepting a location.
         (?P<command>%(commands_taking_locations)s)(?P<force>!?)  \s+   (?P<location>[^\s]+)   |

--- a/pyvim/commands/grammar.py
+++ b/pyvim/commands/grammar.py
@@ -11,6 +11,9 @@ COMMAND_GRAMMAR = compile(r"""
     :*
     \s*
     (
+        # Substitute command
+        ((?P<range_start>\d+)(,(?P<range_end>\d+))?)?  (?P<command>s|substitute) \s* / (?P<search>[^/]*) / (?P<replace>[^/]*) (?P<flags> /g )?    |
+
         # Commands accepting a location.
         (?P<command>%(commands_taking_locations)s)(?P<force>!?)  \s+   (?P<location>[^\s]+)   |
 

--- a/pyvim/commands/handler.py
+++ b/pyvim/commands/handler.py
@@ -1,7 +1,7 @@
 from __future__ import unicode_literals
 
 from .grammar import COMMAND_GRAMMAR
-from .commands import call_command_handler, has_command_handler
+from .commands import call_command_handler, has_command_handler, substitute
 
 __all__ = (
     'handle_command',
@@ -21,6 +21,11 @@ def handle_command(editor, input_string):
     command = variables.get('command')
     go_to_line = variables.get('go_to_line')
     shell_command = variables.get('shell_command')
+    range_start = variables.get('range_start')
+    range_end = variables.get('range_end')
+    search = variables.get('search')
+    replace = variables.get('replace')
+    flags = variables.get('flags', '')
 
     # Call command handler.
 
@@ -35,6 +40,11 @@ def handle_command(editor, input_string):
     elif has_command_handler(command):
         # Handle other 'normal' commands.
         call_command_handler(command, editor, variables)
+
+    elif command in ('s', 'substitute'):
+        flags = flags.lstrip('/')
+        substitute(editor, range_start, range_end, search, replace, flags)
+
     else:
         # For unknown commands, show error message.
         editor.show_message('Not an editor command: %s' % input_string)

--- a/pyvim/editor.py
+++ b/pyvim/editor.py
@@ -129,6 +129,8 @@ class Editor(object):
         # Command line previewer.
         self.previewer = CommandPreviewer(self)
 
+        self.last_substitute_text = ''
+
     def load_initial_files(self, locations, in_tab_pages=False, hsplit=False, vsplit=False):
         """
         Load a list of files.

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -67,6 +67,17 @@ def test_substitute_from_search_history(editor, editor_buffer):
     assert 'Violets are pretty,' in editor_buffer.buffer.text
 
 
+def test_substitute_with_repeat_last_substitution(editor, editor_buffer):
+    given_sample_text(editor_buffer, 'Violet is Violet\n')
+    editor.application.current_search_state.text = 'Lily'
+
+    handle_command(editor, ':s/Violet/Rose')
+    assert 'Rose is Violet' in editor_buffer.buffer.text
+
+    handle_command(editor, ':s')
+    assert 'Rose is Rose' in editor_buffer.buffer.text
+
+
 def test_substitute_flags_empty_flags(editor, editor_buffer):
     given_sample_text(editor_buffer, 'Violet is Violet\n')
     handle_command(editor, ':s/Violet/Rose/')

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -1,0 +1,60 @@
+from pyvim.commands.handler import handle_command
+
+sample_text = """
+Roses are red,
+    Violets are blue,
+Sugar is sweet,
+    And so are you.
+""".lstrip()
+
+def given_sample_text(editor_buffer):
+    editor = editor_buffer.editor
+    editor.window_arrangement._add_editor_buffer(editor_buffer)
+    editor_buffer.buffer.text = sample_text
+    editor.sync_with_prompt_toolkit()
+
+
+def given_cursor_position(editor_buffer, line_number, column=0):
+    editor_buffer.buffer.cursor_position = \
+        editor_buffer.buffer.document.translate_row_col_to_index(line_number - 1, column)
+
+
+def test_substitute_current_line(editor, editor_buffer):
+    given_sample_text(editor_buffer)
+    given_cursor_position(editor_buffer, 2)
+
+    handle_command(editor, ':s/s are/ is')
+
+    assert 'Roses are red,' in editor_buffer.buffer.text
+    assert 'Violet is blue,' in editor_buffer.buffer.text
+    assert 'And so are you.' in editor_buffer.buffer.text
+    assert editor_buffer.buffer.cursor_position \
+        == editor_buffer.buffer.text.index('Violet')
+
+
+def test_substitute_single_line(editor, editor_buffer):
+    given_sample_text(editor_buffer)
+    given_cursor_position(editor_buffer, 1)
+
+    handle_command(editor, ':2s/s are/ is')
+
+    assert 'Roses are red,' in editor_buffer.buffer.text
+    assert 'Violet is blue,' in editor_buffer.buffer.text
+    assert 'And so are you.' in editor_buffer.buffer.text
+    # FIXME: vim would have set the cursor position on the substituted line
+    # assert editor_buffer.buffer.cursor_position \
+    #    == editor_buffer.buffer.text.index('Violet')
+
+
+def test_substitute_range(editor, editor_buffer):
+    given_sample_text(editor_buffer)
+    given_cursor_position(editor_buffer, 1)
+
+    handle_command(editor, ':1,3s/s are/ is')
+
+    assert 'Rose is red,' in editor_buffer.buffer.text
+    assert 'Violet is blue,' in editor_buffer.buffer.text
+    assert 'And so are you.' in editor_buffer.buffer.text
+    # FIXME: vim would have set the cursor position on last substituted line
+    # assert editor_buffer.buffer.cursor_position \
+    #    == editor_buffer.buffer.text.index('Violet')

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -7,10 +7,10 @@ Sugar is sweet,
     And so are you.
 """.lstrip()
 
-def given_sample_text(editor_buffer):
+def given_sample_text(editor_buffer, text=None):
     editor = editor_buffer.editor
     editor.window_arrangement._add_editor_buffer(editor_buffer)
-    editor_buffer.buffer.text = sample_text
+    editor_buffer.buffer.text = text or sample_text
     editor.sync_with_prompt_toolkit()
 
 
@@ -65,3 +65,14 @@ def test_substitute_from_search_history(editor, editor_buffer):
 
     handle_command(editor, ':1,3s//pretty')
     assert 'Violets are pretty,' in editor_buffer.buffer.text
+
+
+def test_substitute_flags_empty_flags(editor, editor_buffer):
+    given_sample_text(editor_buffer, 'Violet is Violet\n')
+    handle_command(editor, ':s/Violet/Rose/')
+    assert 'Rose is Violet' in editor_buffer.buffer.text
+
+def test_substitute_flags_g(editor, editor_buffer):
+    given_sample_text(editor_buffer, 'Rose is Violet\n')
+    handle_command(editor, ':s/Violet/Rose/g')
+    assert 'Rose is Rose' in editor_buffer.buffer.text

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -57,3 +57,11 @@ def test_substitute_range(editor, editor_buffer):
     # FIXME: vim would have set the cursor position on last substituted line
     # assert editor_buffer.buffer.cursor_position \
     #    == editor_buffer.buffer.text.index('Violet')
+
+
+def test_substitute_from_search_history(editor, editor_buffer):
+    given_sample_text(editor_buffer)
+    editor.application.current_search_state.text = 'blue'
+
+    handle_command(editor, ':1,3s//pretty')
+    assert 'Violets are pretty,' in editor_buffer.buffer.text

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -80,7 +80,7 @@ def test_substitute_from_search_history(editor, editor_buffer):
 
 
 def test_substitute_from_substitute_search_history(editor, editor_buffer):
-    given_sample_text(editor_buffer, 'Violet is Violet')
+    given_sample_text(editor_buffer, 'Violet is Violet\n')
 
     handle_command(editor, ':s/Violet/Rose')
     assert 'Rose is Violet' in editor_buffer.buffer.text
@@ -100,6 +100,20 @@ def test_substitute_with_repeat_last_substitution(editor, editor_buffer):
     assert 'Rose is Rose' in editor_buffer.buffer.text
 
 
+def test_substitute_without_replacement_text(editor, editor_buffer):
+    given_sample_text(editor_buffer, 'Violet Violet Violet \n')
+    editor.application.current_search_state.text = 'Lily'
+
+    handle_command(editor, ':s/Violet/')
+    assert ' Violet Violet \n' in editor_buffer.buffer.text
+
+    handle_command(editor, ':s/Violet')
+    assert '  Violet \n' in editor_buffer.buffer.text
+
+    handle_command(editor, ':s/')
+    assert '   \n' in editor_buffer.buffer.text
+
+
 def test_substitute_with_repeat_last_substitution_without_previous_substitution(editor, editor_buffer):
     original_text = 'Violet is blue\n'
     given_sample_text(editor_buffer, original_text)
@@ -117,6 +131,7 @@ def test_substitute_flags_empty_flags(editor, editor_buffer):
     given_sample_text(editor_buffer, 'Violet is Violet\n')
     handle_command(editor, ':s/Violet/Rose/')
     assert 'Rose is Violet' in editor_buffer.buffer.text
+
 
 def test_substitute_flags_g(editor, editor_buffer):
     given_sample_text(editor_buffer, 'Violet is Violet\n')

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -55,8 +55,12 @@ def test_substitute_range(editor, editor_buffer):
     assert 'Violet is blue,' in editor_buffer.buffer.text
     assert 'And so are you.' in editor_buffer.buffer.text
     # FIXME: vim would have set the cursor position on last substituted line
+    #        but we set the cursor position on the end_range even when there
+    #        is not substitution there
     # assert editor_buffer.buffer.cursor_position \
     #    == editor_buffer.buffer.text.index('Violet')
+    assert editor_buffer.buffer.cursor_position \
+        == editor_buffer.buffer.text.index('Sugar')
 
 
 def test_substitute_range_boundaries(editor, editor_buffer):

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -41,9 +41,8 @@ def test_substitute_single_line(editor, editor_buffer):
     assert 'Roses are red,' in editor_buffer.buffer.text
     assert 'Violet is blue,' in editor_buffer.buffer.text
     assert 'And so are you.' in editor_buffer.buffer.text
-    # FIXME: vim would have set the cursor position on the substituted line
-    # assert editor_buffer.buffer.cursor_position \
-    #    == editor_buffer.buffer.text.index('Violet')
+    assert editor_buffer.buffer.cursor_position \
+        == editor_buffer.buffer.text.index('Violet')
 
 
 def test_substitute_range(editor, editor_buffer):

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -88,6 +88,19 @@ def test_substitute_with_repeat_last_substitution(editor, editor_buffer):
     assert 'Rose is Rose' in editor_buffer.buffer.text
 
 
+def test_substitute_with_repeat_last_substitution_without_previous_substitution(editor, editor_buffer):
+    original_text = 'Violet is blue\n'
+    given_sample_text(editor_buffer, original_text)
+
+    handle_command(editor, ':s')
+    assert original_text in editor_buffer.buffer.text
+
+    editor.application.current_search_state.text = 'blue'
+
+    handle_command(editor, ':s')
+    assert 'Violet is \n' in editor_buffer.buffer.text
+
+
 def test_substitute_flags_empty_flags(editor, editor_buffer):
     given_sample_text(editor_buffer, 'Violet is Violet\n')
     handle_command(editor, ':s/Violet/Rose/')

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -67,6 +67,16 @@ def test_substitute_from_search_history(editor, editor_buffer):
     assert 'Violets are pretty,' in editor_buffer.buffer.text
 
 
+def test_substitute_from_substitute_search_history(editor, editor_buffer):
+    given_sample_text(editor_buffer, 'Violet is Violet')
+
+    handle_command(editor, ':s/Violet/Rose')
+    assert 'Rose is Violet' in editor_buffer.buffer.text
+
+    handle_command(editor, ':s//Lily')
+    assert 'Rose is Lily' in editor_buffer.buffer.text
+
+
 def test_substitute_with_repeat_last_substitution(editor, editor_buffer):
     given_sample_text(editor_buffer, 'Violet is Violet\n')
     editor.application.current_search_state.text = 'Lily'

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -94,6 +94,6 @@ def test_substitute_flags_empty_flags(editor, editor_buffer):
     assert 'Rose is Violet' in editor_buffer.buffer.text
 
 def test_substitute_flags_g(editor, editor_buffer):
-    given_sample_text(editor_buffer, 'Rose is Violet\n')
+    given_sample_text(editor_buffer, 'Violet is Violet\n')
     handle_command(editor, ':s/Violet/Rose/g')
     assert 'Rose is Rose' in editor_buffer.buffer.text

--- a/tests/test_substitute.py
+++ b/tests/test_substitute.py
@@ -59,6 +59,14 @@ def test_substitute_range(editor, editor_buffer):
     #    == editor_buffer.buffer.text.index('Violet')
 
 
+def test_substitute_range_boundaries(editor, editor_buffer):
+    given_sample_text(editor_buffer, 'Violet\n' * 4)
+
+    handle_command(editor, ':2,3s/Violet/Rose')
+
+    assert 'Violet\nRose\nRose\nViolet\n' in editor_buffer.buffer.text
+
+
 def test_substitute_from_search_history(editor, editor_buffer):
     given_sample_text(editor_buffer)
     editor.application.current_search_state.text = 'blue'


### PR DESCRIPTION
What works:

- substitute current line (`:s/a/b`)
- substitute single line (`:4s/a/b`)
- substitute range (`:2,4s/a/b`)
- substitute from search history (`/a` then `:s//b`)
- substitute from search substitution history (`:s/a/b` then `:s//c`)
- substitute with repeat last substitution (`:s`)
- substitute g-flags (`:s/a/b/g`)

What doesn't work/not implemented:

- when substituting over a range, vim would finish by jumping the cursor to the last substitution if there is a match; this implementation always move the cursor to the last selected range
- substitution flags other than `g`
- substitution with count (`:s/a/b/5`)
- no previews (`incsearch` or `inccommand`)