### PR TITLE
docs: fix simple typo, underneat -> underneath

### DIFF
--- a/pyvim/layout.py
+++ b/pyvim/layout.py
@@ -528,7 +528,7 @@ class EditorLayout(object):
 
     def _create_window_frame(self, editor_buffer):
         """
-        Create a Window for the buffer, with underneat a status bar.
+        Create a Window for the buffer, with underneath a status bar.
         """
         @Condition
         def wrap_lines():


### PR DESCRIPTION
There is a small typo in pyvim/layout.py.

Should read `underneath` rather than `underneat`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md