### PR TITLE
Update license string in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     name='pyvim',
     author='Jonathan Slenders',
     version=pyvim.__version__,
-    license='LICENSE',
+    license='BSD License',
     url='https://github.com/jonathanslenders/pyvim',
     description='Pure Python Vi Implementation',
     long_description=long_description,


### PR DESCRIPTION
This updates the license string in setup.py to 'BSD License' to match the project's license. This will update the license displayed on the PyPi project page whenever the package metadata is rescanned. This change will allow for automatic license validation.